### PR TITLE
Make function parameters patterns

### DIFF
--- a/src/Koa/Syntax.hs
+++ b/src/Koa/Syntax.hs
@@ -24,7 +24,7 @@ type Definition = DefinitionF Expr
 type DefinitionT = DefinitionF ExprT
 
 -- | An arbitrary identifier binding (e.g. a function parameter).
-data TBinding = TBinding Ident Type deriving (Eq, Show)
+data TBinding = TBinding Pattern Type deriving (Eq, Show)
 
 -- | AST for an expression.
 data ExprF e


### PR DESCRIPTION
Right now, `TBinding` is defined as `TBinding Ident Type`. This makes it "impossible" to declare a function parameter as "mutable".

```koa
fn foo(bar: i32) {
  bar = 3; // error! `bar` is immutable!
}
```

This PR proposes to change it to `TBinding Pattern Type`, allowing parameters to be declared as mutable.

```koa
fn foo(mut bar: i32) {
  bar = 3; // ok!
}
```

As a bonus, this also gives us a way to ignore a parameter (without causing a warning):

```koa
// https://xkcd.com/221/
fn random(_: i32): i32 {
  4
}
```