### PR TITLE
Fix floating point unary negate operator

### DIFF
--- a/src/Koa/Analyser/ToMIR.hs
+++ b/src/Koa/Analyser/ToMIR.hs
@@ -72,7 +72,8 @@ expr (HIR.ExprT (HIR.ECall name args, _)) =
 expr (HIR.ExprT (HIR.EAssign name e, _)) = MIR.EAssign <$> ident name <*> expr e
 expr (HIR.ExprT (HIR.EBinop op lhs rhs, _)) =
   MIR.EBinop <$> typeOf lhs <*> binop op <*> expr lhs <*> expr rhs
-expr (HIR.ExprT (HIR.EUnop op e, _)) = MIR.EUnop <$> unop op <*> expr e
+expr (HIR.ExprT (HIR.EUnop op e, _)) =
+  MIR.EUnop <$> typeOf e <*> unop op <*> expr e
 expr (HIR.ExprT (HIR.ELit lit, ty)) = MIR.EConst <$> lit' ty lit
 
 typeOf :: HIR.ExprT -> Analyser MIR.Type

--- a/src/Koa/Compiler.hs
+++ b/src/Koa/Compiler.hs
@@ -221,10 +221,10 @@ genExpr :: Expr -> Codegen (Maybe AST.Operand)
 -- literal
 genExpr (EConst c) = pure $ llvmConst c
 -- unary op
-genExpr (EUnop operator e) =
+genExpr (EUnop ty operator e) =
   do
     Just e' <- genExpr e
-    Just <$> genUnop operator e'
+    Just <$> genUnop ty operator e'
 -- binary op
 genExpr (EBinop ty op left right) =
   do
@@ -271,9 +271,11 @@ genBlock label bl =
 genInlineBlock :: Block -> Codegen (Maybe AST.Operand)
 genInlineBlock (Block stmts e) = genAllStmts stmts (genExpr e)
 
-genUnop :: Unop -> AST.Operand -> Codegen AST.Operand
-genUnop ONeg = sub (int32 0)
-genUnop ONot = icmp ASTIP.EQ (bit 0)
+genUnop :: Type -> Unop -> AST.Operand -> Codegen AST.Operand
+genUnop TInt32 ONeg = sub (int32 0)
+genUnop TFloat64 ONeg = fsub (double 0)
+genUnop TBool ONot = icmp ASTIP.EQ (bit 0)
+genUnop ty op = error $ "unimplemented unop: " ++ show ty ++ " " ++ show op
 
 genBinop :: Type -> Binop -> AST.Operand -> AST.Operand -> Codegen AST.Operand
 genBinop TInt32 OAdd = add

--- a/src/Koa/Syntax/MIR.hs
+++ b/src/Koa/Syntax/MIR.hs
@@ -40,7 +40,7 @@ data Expr
   | ECall Ident [Expr]
   | EAssign Ident Expr
   | EBinop Type Binop Expr Expr
-  | EUnop Unop Expr
+  | EUnop Type Unop Expr
   | EConst Constant
   deriving (Eq, Show)
 

--- a/tests/operators/floating_point.koa
+++ b/tests/operators/floating_point.koa
@@ -5,7 +5,7 @@ fn main(): i32 {
   let c = a + b;
   let d = c / 2.0;
 
-  if d > 1.0 {
+  if -d < -1.0 {
     0
   } else {
     1


### PR DESCRIPTION
Fixes an issue with the unary negation operator on floating point numbers. This PR is equivalent to #72.

Note: [the `fneg` LLVM instruction](https://releases.llvm.org/9.0.0/docs/LangRef.html#fneg-instruction) would be the correct way to implement it, but `llvm-hs` is missing it...